### PR TITLE
RestClient 외부 api 호출 구현 및 테스트

### DIFF
--- a/src/main/java/com/example/fashionforecastbackend/global/config/RestClientConfig.java
+++ b/src/main/java/com/example/fashionforecastbackend/global/config/RestClientConfig.java
@@ -1,0 +1,18 @@
+package com.example.fashionforecastbackend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+	/*
+	기상청에서 제공하는 서비스키의 경우 이미 인코딩이 된 값이기 때문에 다시 인코딩할 필요가 없다.
+	인코딩을 설정할 필요가 없으므로 기본 설정으로 RestClient를 생성한다.
+	*/
+	@Bean
+	public RestClient restClient() {
+		return RestClient.create();
+	}
+}

--- a/src/main/java/com/example/fashionforecastbackend/weather/api/RestClientWeatherRequester.java
+++ b/src/main/java/com/example/fashionforecastbackend/weather/api/RestClientWeatherRequester.java
@@ -1,0 +1,48 @@
+package com.example.fashionforecastbackend.weather.api;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class RestClientWeatherRequester {
+
+	private final RestClient restClient;
+	private final WeatherApiProperties apiProperties;
+
+	public String getWeatherForecast(String forecastType, String baseDate, String baseTime, int nx, int ny) {
+		String url = getUrl(forecastType, baseDate, baseTime, nx, ny);
+		log.info(url);
+		try {
+			return restClient.get()
+				.uri(url)
+				.retrieve()
+				.body(String.class);
+		} catch (RestClientException e) {
+			log.error("기상청 API를 통해서 날씨 정보를 가져오는데 실패하였습니다.", e);
+			throw new RuntimeException(e);
+		}
+	}
+
+	private String getUrl(String forecastType, String baseDate, String baseTime, int nx, int ny) {
+		return UriComponentsBuilder.fromHttpUrl(apiProperties.getBaseUrl())
+			.path(forecastType)
+			.queryParam("serviceKey", apiProperties.getKey())
+			.queryParam("pageNo", "1")
+			.queryParam("numOfRows", "1000")
+			.queryParam("dataType", "JSON")
+			.queryParam("base_date", baseDate)
+			.queryParam("base_time", baseTime)
+			.queryParam("nx", nx)
+			.queryParam("ny", ny)
+			.build(false)
+			.toUriString();
+	}
+
+}

--- a/src/main/java/com/example/fashionforecastbackend/weather/api/WeatherApiProperties.java
+++ b/src/main/java/com/example/fashionforecastbackend/weather/api/WeatherApiProperties.java
@@ -1,0 +1,17 @@
+package com.example.fashionforecastbackend.weather.api;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Data;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "weather.api")
+public class WeatherApiProperties {
+	private String key;
+	private String baseUrl;
+	private String ultraSrtNcst;
+	private String ultraSrtFcst;
+	private String vilageFcst;
+}

--- a/src/test/java/com/example/fashionforecastbackend/weather/api/RestClientWeatherRequesterTest.java
+++ b/src/test/java/com/example/fashionforecastbackend/weather/api/RestClientWeatherRequesterTest.java
@@ -1,0 +1,87 @@
+package com.example.fashionforecastbackend.weather.api;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+@ExtendWith(MockitoExtension.class)
+class RestClientWeatherRequesterTest {
+	@Mock(answer = Answers.RETURNS_DEEP_STUBS)
+	private RestClient restClient;
+
+	@Mock
+	private WeatherApiProperties apiProperties;
+
+	@InjectMocks
+	private RestClientWeatherRequester restClientWeatherRequester;
+
+	@Test
+	@DisplayName("API 호출이 성공할 경우 응답으로 ok를 반환한다.")
+	void getWeatherForecast_API_호출성공() {
+		// given
+		String mockBaseUrl = "http://mockBaseUrl/";
+		String mockApiKey = "mockApiKey";
+		given(apiProperties.getBaseUrl()).willReturn(mockBaseUrl);
+		given(apiProperties.getKey()).willReturn(mockApiKey);
+
+		String forecastType = "/getVilageFcst";
+		String baseDate = "20240809";
+		String baseTime = "0600";
+		int nx = 60;
+		int ny = 127;
+
+		String path = "/getVilageFcst?serviceKey=";
+		given(restClient.get()
+			.uri(contains(path))
+			.retrieve()
+			.body(String.class)
+		).willReturn("ok");
+
+		// when
+		String response = restClientWeatherRequester.getWeatherForecast(forecastType, baseDate, baseTime, nx, ny);
+
+		// then
+		assertThat(response).isEqualTo("ok");
+	}
+
+	@Test
+	@DisplayName("API 호출이 잘못된 요청값으로 실패할 경우 400상태를 반환한다.")
+	void getWeatherForecast_API_호출실패() {
+		// given
+		String mockBaseUrl = "http://mockBaseUrl/";
+		String mockApiKey = "mockApiKey";
+		given(apiProperties.getBaseUrl()).willReturn(mockBaseUrl);
+		given(apiProperties.getKey()).willReturn(mockApiKey);
+
+		String errorForecastType = "/getVi";
+		String errorBaseDate = "202409";
+		String errorBaseTime = "060";
+		int nx = 60;
+		int ny = 127;
+
+		given(restClient.get()
+			.uri(anyString())
+			.retrieve()
+			.body(String.class)
+		).willThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST) {
+		});
+
+		// when // then
+		assertThatThrownBy(
+			() -> restClientWeatherRequester.getWeatherForecast(errorForecastType, errorBaseDate, errorBaseTime, nx,
+				ny))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessageContaining("400 BAD_REQUEST");
+	}
+}


### PR DESCRIPTION
## 📄 Summary
>
RestTemplate가 deprecated될 가능이 있다는것을 몰랐는데 이주님 덕분에 알게 됐습니다. 👍
RestClient 역시 동기식으로 동작하기 때문에 RestTemplate를 사용했을때와 코드의 변화는 큰 차이가 없었습니다.
하지만 RestClient의 경우 메소드 체이닝 방식의 fluent api 이기 때문에 테스트코드를 작성할때 주의할 점이 있었습니다.

```java
given(webClientWrapper.get()
    .uri(anyString())
    .retrieve()
    .bodyToMono(String.class)
    .block()
).willReturn("ok");
```

mokito를 사용할때 위와 같이 stub객체를 만들면 NPE가 발생하게 됩니다. NPE가 발생하는 이유는 fluent api의 경우 메소드 체이닝 과정에서 여러 객체와 메서드가 숨겨져 사용되고 있기 때문입니다. 따라서 restClient와 webClient와 같은 fluent api는 `@Mock`을 사용한 테스트 코드 작성시 아래와 같이 작성되어야 합니다.

```java
@ExtendWith(MockitoExtension.class)
class ExampleTest {
 
  @Mock
  private WebClient webClient;
 
  @InjectMocks
  private InspirationalQuotesClient cut; // class under test
 
  @Test
  void test() {
 
    WebClient.RequestHeadersUriSpec requestHeadersUriSpec = Mockito.mock(WebClient.RequestHeadersUriSpec.class);
    WebClient.ResponseSpec responseSpec = Mockito.mock(WebClient.ResponseSpec.class);
 
    when(webClient.get()).thenReturn(requestHeadersUriSpec);
    when(requestHeadersUriSpec.uri("/api/quotes")).thenReturn(requestHeadersUriSpec);
    when(requestHeadersUriSpec.retrieve()).thenReturn(responseSpec);
    when(responseSpec.bodyToMono(String.class)).thenReturn(Mono.just("We've escaped hell"));
 
    String result = cut.fetchRandomQuote();
 
    assertEquals("We've escaped hell", result);
  }
}
```
코드를 보면 stub 객체를 만들기 위해 많은 코드 작성이 필요합니다. 하지만 Mockito 는 Answer 라는 객체로 deep stubbing 기능을 사용한다면 stub객체를 보다 간단하게 만들 수 있습니다. restClient를 테스트시 deep stub를 적용하면


```java 
@ExtendWith(MockitoExtension.class)
class RestClientWeatherRequesterTest {

	@Mock(answer = Answers.RETURNS_DEEP_STUBS) // deep stub
	private RestClient restClient;

	@Mock
	private WeatherApiProperties apiProperties;

	@InjectMocks
	private RestClientWeatherRequester restClientWeatherRequester;

	@Test
	@DisplayName("API 호출이 성공할 경우 응답으로 ok를 반환한다.")
	void getWeatherForecast_API_호출성공() {
		// given
		String mockBaseUrl = "http://mockBaseUrl/";
		String mockApiKey = "mockApiKey";
		given(apiProperties.getBaseUrl()).willReturn(mockBaseUrl);
		given(apiProperties.getKey()).willReturn(mockApiKey);

		String forecastType = "/getVilageFcst";
		String baseDate = "20240809";
		String baseTime = "0600";
		int nx = 60;
		int ny = 127;

		String path = "/getVilageFcst?serviceKey=";
		given(restClient.get()
			.uri(contains(path))
			.retrieve()
			.body(String.class)
		).willReturn("ok");

		// when
		String response = restClientWeatherRequester.getWeatherForecast(forecastType, baseDate, baseTime, nx, ny);

		// then
		assertThat(response).isEqualTo("ok");
	}
```


위와 같이 별도의 설정없이 given()만 사용하여 테스트를 작성할 수 있습니다. 

끝!!


## 🙋🏻 More
> 
