### PR TITLE
날씨 요청 관련 유효성 검증

### DIFF
--- a/.github/workflows/CD-EC2-Dev.yml
+++ b/.github/workflows/CD-EC2-Dev.yml
@@ -12,6 +12,7 @@ permissions:
 #develop 브랜치 트리거 제거
 jobs:
   deploy:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: EC2 원격 접속 및 Docker compose

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation("com.opencsv:opencsv:5.5.2")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation ("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     runtimeOnly("com.h2database:h2")

--- a/src/main/java/com/example/fashionforecastbackend/global/BaseTimeEntity.java
+++ b/src/main/java/com/example/fashionforecastbackend/global/BaseTimeEntity.java
@@ -6,6 +6,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
@@ -13,11 +14,13 @@ import lombok.Getter;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public class BaseTimeEntity {
+public abstract class BaseTimeEntity {
 
 	@CreatedDate
+	@Column(nullable = false, updatable = false)
 	private LocalDateTime createdAt;
 
 	@LastModifiedDate
+	@Column(nullable = false)
 	private LocalDateTime modifiedAt;
 }

--- a/src/main/java/com/example/fashionforecastbackend/global/error/ErrorCode.java
+++ b/src/main/java/com/example/fashionforecastbackend/global/error/ErrorCode.java
@@ -11,7 +11,13 @@ public enum ErrorCode {
 	/**
 	 * Etc
 	 */
-	INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "E001", "잘못된 요청입니다.");
+	INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "E001", "잘못된 요청입니다."),
+
+	/**
+	 * 날씨
+	 */
+	INVALID_WEATHER_REQUEST_TIME(HttpStatus.BAD_REQUEST, "W001", "날씨 요청 시간은 과거일 수 없습니다.");
+
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/example/fashionforecastbackend/global/error/exception/InvalidWeatherRequestException.java
+++ b/src/main/java/com/example/fashionforecastbackend/global/error/exception/InvalidWeatherRequestException.java
@@ -1,0 +1,11 @@
+package com.example.fashionforecastbackend.global.error.exception;
+
+import com.example.fashionforecastbackend.global.error.ErrorCode;
+import com.example.fashionforecastbackend.global.error.GeneralException;
+
+public class InvalidWeatherRequestException extends GeneralException {
+
+	public InvalidWeatherRequestException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/example/fashionforecastbackend/weather/dto/WeatherRequestDto.java
+++ b/src/main/java/com/example/fashionforecastbackend/weather/dto/WeatherRequestDto.java
@@ -2,9 +2,24 @@ package com.example.fashionforecastbackend.weather.dto;
 
 import java.time.LocalDateTime;
 
+import org.springframework.format.annotation.DateTimeFormat;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record WeatherRequestDto(
+	@NotNull(message = "시간을 입력해주세요.")
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
 	LocalDateTime now,
+
+	@Min(value = 1, message = "위도는 1 이상이어야 합니다.")
+	@Max(value = 999, message = "위도는 999 이하여야 합니다.")
 	int nx,
+
+	@Min(value = 1, message = "경도는 1 이상이어야 합니다.")
+	@Max(value = 999, message = "경도는 999 이하여야 합니다.")
 	int ny
 ) {
 }

--- a/src/main/java/com/example/fashionforecastbackend/weather/dto/WeatherRequestDto.java
+++ b/src/main/java/com/example/fashionforecastbackend/weather/dto/WeatherRequestDto.java
@@ -6,10 +6,10 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record WeatherRequestDto(
+
 	@NotNull(message = "시간을 입력해주세요.")
 	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
 	LocalDateTime now,

--- a/src/main/java/com/example/fashionforecastbackend/weather/presentation/WeatherController.java
+++ b/src/main/java/com/example/fashionforecastbackend/weather/presentation/WeatherController.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,6 +15,7 @@ import com.example.fashionforecastbackend.weather.dto.WeatherRequestDto;
 import com.example.fashionforecastbackend.weather.dto.WeatherResponseDto;
 import com.example.fashionforecastbackend.weather.service.WeatherService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -25,11 +27,7 @@ public class WeatherController {
 
 	@GetMapping("/forecast")
 	public ApiResponse<List<WeatherResponseDto>> getWeather(
-		@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-		@RequestParam(name = "now") LocalDateTime now,
-		@RequestParam(name = "nx") int nx,
-		@RequestParam(name = "ny") int ny) {
-		WeatherRequestDto dto = new WeatherRequestDto(now, nx, ny);
+		@ModelAttribute @Valid WeatherRequestDto dto) {
 		return ApiResponse.ok(weatherService.getWeather(dto));
 	}
 

--- a/src/main/java/com/example/fashionforecastbackend/weather/presentation/WeatherController.java
+++ b/src/main/java/com/example/fashionforecastbackend/weather/presentation/WeatherController.java
@@ -1,13 +1,10 @@
 package com.example.fashionforecastbackend.weather.presentation;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.fashionforecastbackend.global.response.ApiResponse;

--- a/src/main/java/com/example/fashionforecastbackend/weather/service/Impl/WeatherServiceImpl.java
+++ b/src/main/java/com/example/fashionforecastbackend/weather/service/Impl/WeatherServiceImpl.java
@@ -22,6 +22,7 @@ import com.example.fashionforecastbackend.weather.dto.WeatherRequestDto;
 import com.example.fashionforecastbackend.weather.dto.WeatherResponseDto;
 import com.example.fashionforecastbackend.weather.service.WeatherMapper;
 import com.example.fashionforecastbackend.weather.service.WeatherService;
+import com.example.fashionforecastbackend.weather.util.WeatherValidator;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,11 +36,12 @@ public class WeatherServiceImpl implements WeatherService {
 	private final RegionRepository regionRepository;
 	private final WeatherMapper weatherMapper;
 	private final WeatherRepository weatherRepository;
+	private final WeatherValidator validator;
 
 	@Override
 	public List<WeatherResponseDto> getWeather(final WeatherRequestDto dto) {
 		LocalDateTime now = dto.now();
-		validateDateTime(now);
+		validator.validateDateTime(now);
 		String baseDate = now.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
 		String baseTime = getBaseTime(now);
 		Region region = findRegion(dto.nx(), dto.ny());
@@ -128,10 +130,4 @@ public class WeatherServiceImpl implements WeatherService {
 		return region;
 	}
 
-	private void validateDateTime(LocalDateTime dateTime) {
-		LocalDateTime now = LocalDateTime.now();
-		if (dateTime.isBefore(now.minusMinutes(5))) {
-			throw new InvalidWeatherRequestException(ErrorCode.INVALID_WEATHER_REQUEST_TIME);
-		}
-	}
 }

--- a/src/main/java/com/example/fashionforecastbackend/weather/util/WeatherValidator.java
+++ b/src/main/java/com/example/fashionforecastbackend/weather/util/WeatherValidator.java
@@ -1,0 +1,23 @@
+package com.example.fashionforecastbackend.weather.util;
+
+import java.time.LocalDateTime;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+import com.example.fashionforecastbackend.global.error.ErrorCode;
+import com.example.fashionforecastbackend.global.error.exception.InvalidWeatherRequestException;
+
+@Component
+public class WeatherValidator {
+
+	public void validateDateTime(LocalDateTime dateTime) {
+
+		LocalDateTime now = LocalDateTime.now();
+		if (dateTime.isBefore(now.minusMinutes(5))) {
+			throw new InvalidWeatherRequestException(ErrorCode.INVALID_WEATHER_REQUEST_TIME);
+		}
+
+	}
+}

--- a/src/main/java/com/example/fashionforecastbackend/weather/util/WeatherValidator.java
+++ b/src/main/java/com/example/fashionforecastbackend/weather/util/WeatherValidator.java
@@ -2,8 +2,6 @@ package com.example.fashionforecastbackend.weather.util;
 
 import java.time.LocalDateTime;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
 import com.example.fashionforecastbackend.global.error.ErrorCode;


### PR DESCRIPTION
## 📄 Summary
>
#### 1. 현재 시간보다 5분이상의 과거일 경우 에러 처리
- 통신을 위해 최대 5분정도의 버퍼가 필요하다고 판단
#### 2. 시간, 위도, 경도 형식 및 범위 dto에서 유효성 검증
- 위도, 경도 유효 범위 1~999
- 기상청 api 요청 위도, 경도는 1~999까지 허용되며, 한국과 가장 가까운 지역으로 자동 매핑해줌

### 🎯`과거 검증`은 어디서 하면 좋을까요??
위도, 경도의 경우 범위와 값의 유무만 판단하면 되기 때문에 컨트롤러에서 유효성을 검증하고 서비스 레이어로 전달해주고 있습니다. 하지만, 시간의 경우 값의 유무 및 타입만 컨트롤러에서 검증하고 `과거 검증` 을 하는 부분은 어디서 하면 좋을지 아래와 같이 고민해보았습니다.

#### @FutureOrPresent 사용
- 시간이 현재와 미래인 경우에만 허용
- dto에 해당 어노테이션만 붙이면 되므로 편리함, 추가 검증 로직 구현 필요 없음
- 클라이언트와 시간이 동기화 되지 않으면 에러가 발생할 가능성이 크다 (사용하지 않은 결정적인 이유)

#### 컨트롤러에서 진행
- 과거인지 검증하는 것은 값의 유효성이 아닌 적절성을 체크하는것이기 때문에 컨트롤러와는 어울리지 않는다고 생각

#### 서비스에서 진행
- 적절성 체크는 비즈니스 로직과 맞닿아 있기 때문에 서비스에서 진행하는것이 자연스럽다고 판단

결과적으로 저는 서비스에서 과거 유무를 검증하였고, 스프링 DI 및 쉬운 테스트 코드 작성을 위해 validator를 빈으로 관리하는것을 선택하였습니다. 이게 정답이 없는 부분이라 관련해서 이주님 의견도 들어보고싶습니다~ 답변 부탁드립니다!

## 🙋🏻 More
>
체감온도는 기획쪽에서 픽스해주면 추가할 예정입니다.
그리고 다음주 월요일에 옷추천 관련해서는 erd가 복잡하지 않으니, 기능 중심으로 논의하면 좋을것 같습니다~
