### PR TITLE
기상청 api 호출 개선 및 날씨 도메인 queryDsl 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 ### application.yml ###
 application*.yml
 
+### Querydsl ###
+/src/main/generated
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,8 @@ repositories {
 }
 
 val snippetsDir = file("build/generated-snippets")
+// QClass 파일 생성 위치 지정
+val generated: String = "src/main/generated"
 
 dependencies {
     implementation("org.springframework.retry:spring-retry")
@@ -36,6 +38,13 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     runtimeOnly("com.h2database:h2")
     runtimeOnly("com.mysql:mysql-connector-j")
+
+    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+    annotationProcessor("com.querydsl:querydsl-apt:5.0.0:jakarta")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+
+
     annotationProcessor("org.projectlombok:lombok")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
@@ -44,6 +53,12 @@ dependencies {
     testImplementation("io.rest-assured:rest-assured:5.1.1")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
+
+// QClass 파일 생성 위치 지정
+tasks.withType<JavaCompile>().configureEach {
+    options.generatedSourceOutputDirectory.set(file(generated))
+}
+
 
 // 서브모듈 설정파일 복사
 tasks.register<Copy>("copySecret") {
@@ -94,4 +109,9 @@ tasks {
         // AsciiDoc 파일 생성이 완료되어야 build 진행
         dependsOn(asciidoctor)
     }
+}
+
+// Gradle clean 시 QClass 디렉토리 삭제
+tasks.clean {
+    delete(file(generated))
 }

--- a/src/main/java/com/example/fashionforecastbackend/global/config/QueryDslConfig.java
+++ b/src/main/java/com/example/fashionforecastbackend/global/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package com.example.fashionforecastbackend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/src/main/java/com/example/fashionforecastbackend/weather/domain/repository/WeatherCustomRepositoryImpl.java
+++ b/src/main/java/com/example/fashionforecastbackend/weather/domain/repository/WeatherCustomRepositoryImpl.java
@@ -21,7 +21,7 @@ public class WeatherCustomRepositoryImpl implements WeatherCustomRepository {
 	public void saveAll(Collection<Weather> weathers) {
 
 		String sql =
-			"INSERT INTO weather (base_date, base_time, reh, tmp, wsd, season, sky_status, rain_type, fcst_date, fcst_time,"
+			"INSERT IGNORE INTO weather (base_date, base_time, reh, tmp, wsd, season, sky_status, rain_type, fcst_date, fcst_time,"
 				+ "pcp, pop, nx, ny, created_at, modified_at)"
 				+ " VALUES (:base_date, :base_time, :reh, :tmp, :wsd, :season, :sky_status, :rain_type, :fcst_date, :fcst_time,"
 				+ ":pcp, :pop, :nx, :ny, :created_at, :modified_at)";

--- a/src/main/java/com/example/fashionforecastbackend/weather/domain/repository/WeatherQueryRepository.java
+++ b/src/main/java/com/example/fashionforecastbackend/weather/domain/repository/WeatherQueryRepository.java
@@ -1,0 +1,15 @@
+package com.example.fashionforecastbackend.weather.domain.repository;
+
+import java.util.List;
+
+import com.example.fashionforecastbackend.weather.domain.Weather;
+import com.example.fashionforecastbackend.weather.dto.request.WeatherFilter;
+
+public interface WeatherQueryRepository {
+
+	List<Weather> findWeather(WeatherFilter weatherFilter);
+
+	void deletePastWeathers(String nowBaseDateTime);
+
+
+}

--- a/src/main/java/com/example/fashionforecastbackend/weather/domain/repository/WeatherQueryRepositoryImpl.java
+++ b/src/main/java/com/example/fashionforecastbackend/weather/domain/repository/WeatherQueryRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.example.fashionforecastbackend.weather.domain.repository;
+
+import static com.example.fashionforecastbackend.weather.domain.QWeather.*;
+
+import java.util.List;
+
+import com.example.fashionforecastbackend.weather.domain.Weather;
+import com.example.fashionforecastbackend.weather.dto.request.WeatherFilter;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class WeatherQueryRepositoryImpl implements WeatherQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<Weather> findWeather(WeatherFilter weatherFilter) {
+		return queryFactory
+			.selectFrom(weather)
+			.where(
+				weather.baseDate.eq(weatherFilter.baseDate()),
+				weather.baseTime.eq(weatherFilter.baseTime()),
+				weather.nx.eq(weatherFilter.nx()),
+				weather.ny.eq(weatherFilter.ny()),
+				weather.fcstDate.concat(weather.fcstTime).goe(weatherFilter.startDate() + weatherFilter.startTime()),
+				weather.fcstDate.concat(weather.fcstTime).loe(weatherFilter.endDate() + weatherFilter.endTime())
+			)
+			.orderBy(weather.fcstDate.asc(), weather.fcstTime.asc())
+			.fetch();
+	}
+
+	@Override
+	public void deletePastWeathers(String nowBaseDateTime) {
+		queryFactory
+			.delete(weather)
+			.where(weather.baseDate.concat(weather.baseTime).lt(nowBaseDateTime))
+			.execute();
+	}
+
+}

--- a/src/main/java/com/example/fashionforecastbackend/weather/domain/repository/WeatherRepository.java
+++ b/src/main/java/com/example/fashionforecastbackend/weather/domain/repository/WeatherRepository.java
@@ -1,21 +1,11 @@
 package com.example.fashionforecastbackend.weather.domain.repository;
 
-import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.example.fashionforecastbackend.weather.domain.Weather;
 
 @Repository
-public interface WeatherRepository extends JpaRepository<Weather, Long>, WeatherCustomRepository {
+public interface WeatherRepository extends JpaRepository<Weather, Long>, WeatherCustomRepository, WeatherQueryRepository {
 
-	@Query("SELECT w FROM Weather w WHERE w.baseDate = :baseDate AND w.baseTime = :baseTime AND w.nx = :nx AND w.ny = :ny ORDER BY w.fcstDate ASC, w.fcstTime ASC")
-	List<Weather> findWeather(String baseDate, String baseTime, int nx, int ny);
-
-	@Modifying
-	@Query("DELETE FROM Weather w WHERE w.baseDate <= :baseDate AND w.baseTime < :baseTime")
-	void deletePastWeathers(String baseDate, String baseTime);
 }

--- a/src/main/java/com/example/fashionforecastbackend/weather/dto/response/WeatherResponse.java
+++ b/src/main/java/com/example/fashionforecastbackend/weather/dto/response/WeatherResponse.java
@@ -7,13 +7,14 @@ import com.example.fashionforecastbackend.weather.domain.Season;
 public record WeatherResponse(
 	Season season,
 	int extremumTmp,
+	int maxMinTmpDiff,
 	int maximumPop,
 	double maximumPcp,
 	List<WeatherForecast> forecasts
 
 ) {
-	public static WeatherResponse of(Season season, int extremumTmp, int maximumPop,
+	public static WeatherResponse of(Season season, int extremumTmp, int maxMinTmpDiff, int maximumPop,
 		double maximumPcp, List<WeatherForecast> forecasts) {
-		return new WeatherResponse(season, extremumTmp, maximumPop, maximumPcp, forecasts);
+		return new WeatherResponse(season, extremumTmp, maxMinTmpDiff, maximumPop, maximumPcp, forecasts);
 	}
 }

--- a/src/main/java/com/example/fashionforecastbackend/weather/service/WeatherMapper.java
+++ b/src/main/java/com/example/fashionforecastbackend/weather/service/WeatherMapper.java
@@ -33,6 +33,7 @@ public class WeatherMapper {
 
 	private final ObjectMapper objectMapper;
 
+
 	public List<WeatherForecast> convertToWeatherResponseDto(Collection<Weather> weathers) {
 		return weathers.stream()
 			.map(WeatherForecast::from)
@@ -52,7 +53,7 @@ public class WeatherMapper {
 		}
 	}
 
-	public Collection<Weather> convertToWeathers(List<WeatherApi> responses, Region region) {
+	public List<Weather> convertToWeathers(List<WeatherApi> responses, Region region) {
 		LocalDate now = LocalDate.now();
 		String tomorrow = now.plusDays(1).format(DateTimeFormatter.ofPattern("yyyyMMdd"));
 		Map<String, Weather> weatherMap = new HashMap<>();
@@ -63,7 +64,7 @@ public class WeatherMapper {
 			}
 			setWeatherForecast(response, region, weatherMap);
 		}
-		return weatherMap.values();
+		return weatherMap.values().stream().toList();
 	}
 
 	private void setWeatherForecast(WeatherApi response, Region region, Map<String, Weather> weatherMap) {

--- a/src/main/resources/static/docs/docs.html
+++ b/src/main/resources/static/docs/docs.html
@@ -905,7 +905,7 @@ Content-Type: application/json
 Content-Type: application/json;charset=UTF-8
 
 {
-  "uuid" : "db4ce5c5-32d5-4d88-92a8-cccf5b812386"
+  "uuid" : "209640e4-930c-476a-bf00-06438a82700d"
 }</code></pre>
 </div>
 </div>
@@ -949,7 +949,7 @@ Content-Type: application/json
 
 {
   "data" : {
-    "uuid" : "db4ce5c5-32d5-4d88-92a8-cccf5b812386",
+    "uuid" : "209640e4-930c-476a-bf00-06438a82700d",
     "isNewGuest" : false
   },
   "status" : 200,

--- a/src/main/resources/static/docs/docs.html
+++ b/src/main/resources/static/docs/docs.html
@@ -608,6 +608,7 @@ Content-Type: application/json
   "data" : {
     "season" : "SUMMER",
     "extremumTmp" : 36,
+    "maxMinTmpDiff" : 0,
     "maximumPop" : 30,
     "maximumPcp" : 0.0,
     "forecasts" : [ {
@@ -730,6 +731,11 @@ Content-Type: application/json
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.extremumTmp</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">최고 또는 최저 기온</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.maxMinTmpDiff</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">최고 최저 기온차</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.maximumPop</code></p></td>
@@ -905,7 +911,7 @@ Content-Type: application/json
 Content-Type: application/json;charset=UTF-8
 
 {
-  "uuid" : "209640e4-930c-476a-bf00-06438a82700d"
+  "uuid" : "7bcedeb1-a947-405a-89c2-2fd31367fc78"
 }</code></pre>
 </div>
 </div>
@@ -949,7 +955,7 @@ Content-Type: application/json
 
 {
   "data" : {
-    "uuid" : "209640e4-930c-476a-bf00-06438a82700d",
+    "uuid" : "7bcedeb1-a947-405a-89c2-2fd31367fc78",
     "isNewGuest" : false
   },
   "status" : 200,

--- a/src/test/java/com/example/fashionforecastbackend/region/domain/repository/RegionRepositoryTest.java
+++ b/src/test/java/com/example/fashionforecastbackend/region/domain/repository/RegionRepositoryTest.java
@@ -9,12 +9,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
+import com.example.fashionforecastbackend.global.config.QueryDslConfig;
 import com.example.fashionforecastbackend.region.domain.Address;
 import com.example.fashionforecastbackend.region.domain.Region;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(QueryDslConfig.class)
 class RegionRepositoryTest {
 
 	@Autowired

--- a/src/test/java/com/example/fashionforecastbackend/weather/domain/repository/WeatherRepositoryTest.java
+++ b/src/test/java/com/example/fashionforecastbackend/weather/domain/repository/WeatherRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import com.example.fashionforecastbackend.weather.domain.Weather;
+import com.example.fashionforecastbackend.weather.dto.request.WeatherFilter;
 import com.example.fashionforecastbackend.weather.fixture.WeatherFixture;
 
 @DataJpaTest
@@ -31,8 +32,9 @@ class WeatherRepositoryTest {
 		Weather weather4 = WeatherFixture.createWeather("20240812", "1400", "20240812", "1600", 120, 67);
 		//when
 		weatherRepository.saveAll(List.of(weather1, weather2, weather3, weather4));
-		List<Weather> records1 = weatherRepository.findWeather("20240811", "1400", 120, 67);
-		List<Weather> records2 = weatherRepository.findWeather("20240812", "1400", 120, 67);
+		WeatherFilter weatherFilter = WeatherFixture.WEATHER_FILTER;
+		List<Weather> records1 = weatherRepository.findWeather(weatherFilter);
+		List<Weather> records2 = weatherRepository.findWeather(weatherFilter);
 		//then
 		assertThat(records1).isNotEmpty();
 		assertThat(records2).isNotEmpty();
@@ -47,12 +49,14 @@ class WeatherRepositoryTest {
 		Weather weather3 = WeatherFixture.createWeather("20240812", "1400", "20240812", "1500", 120, 67);
 		Weather weather4 = WeatherFixture.createWeather("20240812", "1400", "20240812", "1600", 120, 67);
 		weatherRepository.saveAll(List.of(weather1, weather2, weather3, weather4));
+		WeatherFilter weatherFilter = WeatherFixture.WEATHER_FILTER;
+
 		//when
-		weatherRepository.deletePastWeathers("20240812", "1500");
+		weatherRepository.deletePastWeathers("20240812" + "1500");
 
 		//then
-		List<Weather> pastWeathers1 = weatherRepository.findWeather("20240811", "1400", 120, 67);
-		List<Weather> pastWeathers2 = weatherRepository.findWeather("20240812", "1400", 120, 67);
+		List<Weather> pastWeathers1 = weatherRepository.findWeather(weatherFilter);
+		List<Weather> pastWeathers2 = weatherRepository.findWeather(weatherFilter);
 		assertAll(
 			() -> assertThat(pastWeathers1).isEmpty(),
 			() -> assertThat(pastWeathers2).isEmpty()

--- a/src/test/java/com/example/fashionforecastbackend/weather/domain/repository/WeatherRepositoryTest.java
+++ b/src/test/java/com/example/fashionforecastbackend/weather/domain/repository/WeatherRepositoryTest.java
@@ -10,13 +10,16 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
+import com.example.fashionforecastbackend.global.config.QueryDslConfig;
 import com.example.fashionforecastbackend.weather.domain.Weather;
 import com.example.fashionforecastbackend.weather.dto.request.WeatherFilter;
 import com.example.fashionforecastbackend.weather.fixture.WeatherFixture;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(QueryDslConfig.class)
 class WeatherRepositoryTest {
 
 	@Autowired
@@ -26,18 +29,17 @@ class WeatherRepositoryTest {
 	@Test
 	void saveAllTest() throws Exception {
 		//given
-		Weather weather1 = WeatherFixture.createWeather("20240811", "1400", "20240811", "1500", 120, 67);
-		Weather weather2 = WeatherFixture.createWeather("20240811", "1400", "20240811", "1600", 120, 67);
-		Weather weather3 = WeatherFixture.createWeather("20240812", "1400", "20240812", "1500", 120, 67);
-		Weather weather4 = WeatherFixture.createWeather("20240812", "1400", "20240812", "1600", 120, 67);
+		Weather weather1 = WeatherFixture.createWeather("20240811", "1400", "20240811", "1500", 60, 127);
+		Weather weather2 = WeatherFixture.createWeather("20240811", "1400", "20240811", "1600", 60, 127);
+		Weather weather3 = WeatherFixture.createWeather("20240812", "1400", "20240812", "1500", 60, 127);
+		Weather weather4 = WeatherFixture.createWeather("20240812", "1400", "20240812", "1600", 60, 127);
 		//when
 		weatherRepository.saveAll(List.of(weather1, weather2, weather3, weather4));
 		WeatherFilter weatherFilter = WeatherFixture.WEATHER_FILTER;
-		List<Weather> records1 = weatherRepository.findWeather(weatherFilter);
-		List<Weather> records2 = weatherRepository.findWeather(weatherFilter);
+		List<Weather> records = weatherRepository.findWeather(weatherFilter);
+
 		//then
-		assertThat(records1).isNotEmpty();
-		assertThat(records2).isNotEmpty();
+		assertThat(records).isNotEmpty();
 	}
 	
 	@DisplayName("baseDate = 20240812, baseTime = 1500 보다 과거인 날씨 데이터를 삭제한다.")

--- a/src/test/java/com/example/fashionforecastbackend/weather/fixture/WeatherFixture.java
+++ b/src/test/java/com/example/fashionforecastbackend/weather/fixture/WeatherFixture.java
@@ -14,7 +14,7 @@ import com.example.fashionforecastbackend.weather.dto.response.WeatherResponse;
 public class WeatherFixture {
 
 	public static final List<WeatherForecast> WEATHER_FORECASTS = generateWeatherResponseDtos("20240811", "1400");
-	public static final WeatherResponse WEATHER_RESPONSE = WeatherResponse.of(Season.SUMMER, 36, 30,
+	public static final WeatherResponse WEATHER_RESPONSE = WeatherResponse.of(Season.SUMMER, 36, 0, 30,
 		0.0, WEATHER_FORECASTS);
 	public static final List<Weather> WEATHERS = List.of(
 		createWeather("20240811", "1400", "20240811", "1500", 120, 67),

--- a/src/test/java/com/example/fashionforecastbackend/weather/fixture/WeatherFixture.java
+++ b/src/test/java/com/example/fashionforecastbackend/weather/fixture/WeatherFixture.java
@@ -7,6 +7,7 @@ import com.example.fashionforecastbackend.weather.domain.RainType;
 import com.example.fashionforecastbackend.weather.domain.Season;
 import com.example.fashionforecastbackend.weather.domain.SkyStatus;
 import com.example.fashionforecastbackend.weather.domain.Weather;
+import com.example.fashionforecastbackend.weather.dto.request.WeatherFilter;
 import com.example.fashionforecastbackend.weather.dto.response.WeatherForecast;
 import com.example.fashionforecastbackend.weather.dto.response.WeatherResponse;
 
@@ -23,6 +24,9 @@ public class WeatherFixture {
 		createWeather("20240811", "1400", "20240811", "1900", 120, 67)
 	);
 
+	public static final WeatherFilter WEATHER_FILTER = WeatherFilter.of("20240811", "1400", "20240811", "1500",
+		"20240811", "1900", 60, 127);
+
 	private static List<WeatherForecast> generateWeatherResponseDtos(String baseDate, String baseTime) {
 		List<WeatherForecast> responses = new ArrayList<>();
 
@@ -34,7 +38,6 @@ public class WeatherFixture {
 			String fcstTime = String.format("%02d00", t);
 			responses.add(WeatherForecast.from(createWeather(baseDate, baseTime, baseDate, fcstTime, 60, 127)));
 		}
-
 
 		return responses;
 	}

--- a/src/test/java/com/example/fashionforecastbackend/weather/presentation/WeatherControllerTest.java
+++ b/src/test/java/com/example/fashionforecastbackend/weather/presentation/WeatherControllerTest.java
@@ -79,6 +79,7 @@ class WeatherControllerTest extends ControllerTest {
 					.andWithPrefix("data.",
 						fieldWithPath("season").type(JsonFieldType.STRING).description("계절"),
 						fieldWithPath("extremumTmp").type(JsonFieldType.NUMBER).description("최고 또는 최저 기온"),
+						fieldWithPath("maxMinTmpDiff").type(JsonFieldType.NUMBER).description("최고 최저 기온차"),
 						fieldWithPath("maximumPop").type(JsonFieldType.NUMBER).description("최대 강수확률"),
 						fieldWithPath("maximumPcp").type(JsonFieldType.NUMBER).description("최대 강수량"),
 						fieldWithPath("forecasts").type(JsonFieldType.ARRAY).description("날씨 예보 목록")

--- a/src/test/java/com/example/fashionforecastbackend/weather/service/WeatherServiceTest.java
+++ b/src/test/java/com/example/fashionforecastbackend/weather/service/WeatherServiceTest.java
@@ -21,6 +21,7 @@ import com.example.fashionforecastbackend.region.domain.Region;
 import com.example.fashionforecastbackend.region.domain.repository.RegionRepository;
 import com.example.fashionforecastbackend.weather.domain.Weather;
 import com.example.fashionforecastbackend.weather.domain.repository.WeatherRepository;
+import com.example.fashionforecastbackend.weather.dto.request.WeatherFilter;
 import com.example.fashionforecastbackend.weather.dto.request.WeatherRequest;
 import com.example.fashionforecastbackend.weather.dto.response.WeatherForecast;
 import com.example.fashionforecastbackend.weather.fixture.WeatherFixture;
@@ -56,11 +57,12 @@ class WeatherServiceTest {
 			.nx(60)
 			.ny(127)
 			.build();
+		WeatherFilter weatherFilter = WeatherFixture.WEATHER_FILTER;
 		List<Weather> weathers = WeatherFixture.WEATHERS;
 		List<WeatherForecast> forecasts = WeatherFixture.WEATHER_FORECASTS;
 
 		given(regionRepository.findByNxAndNy(60, 127)).willReturn(Optional.of(region));
-		given(weatherRepository.findWeather("20240811", "1400", 60, 127)).willReturn(weathers);
+		given(weatherRepository.findWeather(weatherFilter)).willReturn(weathers);
 		given(weatherMapper.convertToWeatherResponseDto(weathers)).willReturn(forecasts);
 		//when
 		List<WeatherForecast> result = weatherService.getWeather(requestDto).forecasts();
@@ -71,7 +73,7 @@ class WeatherServiceTest {
 		assertThat(result).isEqualTo(forecasts);
 
 		verify(regionRepository).findByNxAndNy(60, 127);
-		verify(weatherRepository).findWeather("20240811", "1400", 60, 127);
+		verify(weatherRepository).findWeather(weatherFilter);
 		verify(weatherMapper).convertToWeatherResponseDto(weathers);
 
 	}
@@ -91,9 +93,11 @@ class WeatherServiceTest {
 			.ny(127)
 			.build();
 		List<Weather> weathers = WeatherFixture.WEATHERS;
+		WeatherFilter weatherFilter = WeatherFixture.WEATHER_FILTER;
+
 
 		given(regionRepository.findByNxAndNy(60, 127)).willReturn(Optional.of(region));
-		given(weatherRepository.findWeather("20240811", "1400", 60, 127)).willReturn(weathers);
+		given(weatherRepository.findWeather(weatherFilter)).willReturn(weathers);
 		given(weatherMapper.convertToWeatherResponseDto(weathers)).willThrow(
 			new RuntimeException("날씨 데이터를 변환하는 과정중에 에러가 발생"));
 
@@ -103,7 +107,7 @@ class WeatherServiceTest {
 			.hasMessageContaining("날씨 데이터를 변환하는 과정중에 에러가 발생");
 
 		verify(regionRepository).findByNxAndNy(60, 127);
-		verify(weatherRepository).findWeather("20240811", "1400", 60, 127);
+		verify(weatherRepository).findWeather(weatherFilter);
 
 	}
 


### PR DESCRIPTION
## 📄 Summary
>
#38 

### ✅ 기상청 api 호출 개선
```java
<OpenAPI_ServiceResponse>
	<cmmMsgHeader>
		<errMsg>SERVICE ERROR</errMsg>
		<returnAuthMsg>HTTP ROUTING ERROR</returnAuthMsg>
		<returnReasonCode>04</returnReasonCode>
	</cmmMsgHeader>
</OpenAPI_ServiceResponse>
```
- 기상청 서버에서 간헐적으로 04 코드 SERVICE_ERROR를 응답함
- 원인은 endPoint서버가 응답이 지연 중일때 발생하는 것으로 확인
- 기상청 api 호출 시 1초간격으로 재시도 하게끔 수정
- numOfRows를 600으로 낮춰서 최대 2일치의 데이터만 가져오도록 수정

### ✅ 날씨 도메인에 queryDsl 적용
- 날씨 정보를 조회 및 삭제 하는 동적쿼리를 queryDsl 사용하여 개선

### ✅ 최고 최저 기온차 로직 추가

### ✅ 날씨 데이터 중복 저장 부분 개선
- Mysql의 INSERT IGNORE 구문을 이용해서 중복 저장이 안되게끔 수정
- INSERT IGNORE 구문은 Hibernate에서 지원하지 않으므로 H2로 빌드 또는 테스트하면 에러가 발생할 수 있음

## 🙋🏻 More
> close #38 
