### PR TITLE
MemberOutfit 문제 개선

### DIFF
--- a/src/main/java/com/example/fashionforecastbackend/global/login/service/LoginService.java
+++ b/src/main/java/com/example/fashionforecastbackend/global/login/service/LoginService.java
@@ -10,7 +10,9 @@ public interface LoginService {
 	AccessTokenResponse renewTokens(final AccessTokenRequest request, final String refreshToken,
 		final HttpServletResponse response);
 
-	void removeRefreshToken(final String refreshTokenRequest);
+	void removeRefreshToken(final Long memberId);
+
+	void revokeMember(final Long memberId);
 
 	AccessTokenResponse issueAccessToken(final String refreshTokenRequest);
 }

--- a/src/main/java/com/example/fashionforecastbackend/listener/DeleteEventListener.java
+++ b/src/main/java/com/example/fashionforecastbackend/listener/DeleteEventListener.java
@@ -1,0 +1,33 @@
+package com.example.fashionforecastbackend.listener;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.example.fashionforecastbackend.member.domain.MemberDeleteEvent;
+import com.example.fashionforecastbackend.member.domain.repository.MemberOutfitRepository;
+import com.example.fashionforecastbackend.member.domain.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * TODO.1 계정 정보 끊는 로직 추가
+ */
+@Component
+@RequiredArgsConstructor
+public class DeleteEventListener {
+
+	private final MemberRepository memberRepository;
+	private final MemberOutfitRepository memberOutfitRepository;
+
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@TransactionalEventListener(fallbackExecution = true)
+	public void deleteMemberWithOutfits (final MemberDeleteEvent event) {
+		final Long memberId = event.memberId();
+		memberOutfitRepository.deleteAllByMemberId(memberId);
+		memberRepository.deleteById(memberId);
+	}
+
+}

--- a/src/main/java/com/example/fashionforecastbackend/member/domain/MemberDeleteEvent.java
+++ b/src/main/java/com/example/fashionforecastbackend/member/domain/MemberDeleteEvent.java
@@ -1,0 +1,10 @@
+package com.example.fashionforecastbackend.member.domain;
+
+public record MemberDeleteEvent(
+	Long memberId
+) {
+
+	public static MemberDeleteEvent of(final Long memberId) {
+		return new MemberDeleteEvent(memberId);
+	}
+}

--- a/src/main/java/com/example/fashionforecastbackend/member/domain/MemberOutfit.java
+++ b/src/main/java/com/example/fashionforecastbackend/member/domain/MemberOutfit.java
@@ -15,7 +15,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -41,7 +40,7 @@ public class MemberOutfit extends BaseTimeEntity {
 
 	private boolean isDeleted = false;
 
-	@OneToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "temp_stage_id", nullable = false)
 	private TempStage tempStage;
 

--- a/src/main/java/com/example/fashionforecastbackend/member/domain/repository/MemberOutfitRepository.java
+++ b/src/main/java/com/example/fashionforecastbackend/member/domain/repository/MemberOutfitRepository.java
@@ -20,7 +20,7 @@ public interface MemberOutfitRepository extends JpaRepository<MemberOutfit, Long
 	List<MemberOutfit> findByMemberIdAndTempStageId(@Param("memberId") final Long memberId,
 		@Param("tempStageId") final Long tempStageId);
 
-	@Query("SELECT mo FROM MemberOutfit mo "
+	@Query("SELECT COUNT(mo) FROM MemberOutfit mo "
 		+ "WHERE mo.member.id = :memberId AND mo.tempStage.id = :tempStageId AND mo.isDeleted = false")
 	Integer countByTempStageIdAndMemberId(final @Param("tempStageId") Long tempStageId,
 		final @Param("memberId") Long memberId);

--- a/src/main/java/com/example/fashionforecastbackend/member/domain/repository/MemberOutfitRepository.java
+++ b/src/main/java/com/example/fashionforecastbackend/member/domain/repository/MemberOutfitRepository.java
@@ -3,6 +3,7 @@ package com.example.fashionforecastbackend.member.domain.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -23,4 +24,7 @@ public interface MemberOutfitRepository extends JpaRepository<MemberOutfit, Long
 		+ "WHERE mo.member.id = :memberId AND mo.tempStage.id = :tempStageId AND mo.isDeleted = false")
 	Integer countByTempStageIdAndMemberId(final @Param("tempStageId") Long tempStageId,
 		final @Param("memberId") Long memberId);
+
+	@Modifying
+	void deleteAllByMemberId(final Long memberId);
 }

--- a/src/main/java/com/example/fashionforecastbackend/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/example/fashionforecastbackend/member/domain/repository/MemberRepository.java
@@ -3,6 +3,7 @@ package com.example.fashionforecastbackend.member.domain.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 
 import com.example.fashionforecastbackend.member.domain.Member;
 import com.example.fashionforecastbackend.member.domain.constant.MemberJoinType;
@@ -12,4 +13,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByJoinTypeAndSocialId(MemberJoinType joinType, String socialId);
 
 	boolean existsByJoinTypeAndSocialId(MemberJoinType joinType, String socialId);
+
+	@Modifying
+	void deleteById(final Long memberId);
+
 }

--- a/src/test/java/com/example/fashionforecastbackend/listener/DeleteEventListenerTest.java
+++ b/src/test/java/com/example/fashionforecastbackend/listener/DeleteEventListenerTest.java
@@ -1,0 +1,42 @@
+package com.example.fashionforecastbackend.listener;
+
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.fashionforecastbackend.member.domain.MemberDeleteEvent;
+import com.example.fashionforecastbackend.member.domain.repository.MemberOutfitRepository;
+import com.example.fashionforecastbackend.member.domain.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteEventListenerTest {
+	
+	@Mock
+	private MemberRepository memberRepository;
+	
+	@Mock
+	private MemberOutfitRepository memberOutfitRepository;
+	
+	@InjectMocks
+	private DeleteEventListener deleteEventListener;
+	
+	@Test
+	@DisplayName("deleteMemberWithOutfits 레파지토리 호출 성공")
+	void deleteMemberWithOutfitsTest() throws Exception {
+	    //given
+		final MemberDeleteEvent memberDeleteEvent = MemberDeleteEvent.of(1L);
+		willDoNothing().given(memberOutfitRepository).deleteAllByMemberId(memberDeleteEvent.memberId());
+		willDoNothing().given(memberRepository).deleteById(memberDeleteEvent.memberId());
+		//when
+		deleteEventListener.deleteMemberWithOutfits(memberDeleteEvent);
+	    //then
+		then(memberOutfitRepository).should().deleteAllByMemberId(memberDeleteEvent.memberId());
+		then(memberRepository).should().deleteById(memberDeleteEvent.memberId());
+	}
+
+}


### PR DESCRIPTION
## 📄 Summary
>
#135 

count 메서드 null 반환외에도 MemberOutfit이 중복저장되지 않은 문제가 있었습니다.
MemberOutfit과 TempStage가 일대일 매핑으로 인해 유니크 제약이 걸렸던 것이 원인이었습니다.

따라서 아래와 같이 수정하였습니다.

- countByTempStageIdAndMemberId() 누락된 count 쿼리를 추가하였습니다.
- MemberOutfit 과 TempStage의 연관관계를 다대일로 수정하였습니다.


## 🙋🏻 More
>
