### PR TITLE
계정 탈퇴 api 수정

### DIFF
--- a/src/main/java/com/example/fashionforecastbackend/global/login/presentation/LoginController.java
+++ b/src/main/java/com/example/fashionforecastbackend/global/login/presentation/LoginController.java
@@ -38,9 +38,11 @@ public class LoginController {
 	}
 
 	@DeleteMapping("/account")
-	public ApiResponse<Void> deleteAccount(@AuthenticationPrincipal UserDetail principal) {
+	public ApiResponse<Void> deleteAccount(
+		@AuthenticationPrincipal final UserDetail principal,
+		HttpServletResponse response) {
 		final Long memberId = principal.memberId();
-		loginService.deleteAccount(memberId);
+		loginService.deleteAccount(memberId, response);
 		return ApiResponse.noContent();
 	}
 }

--- a/src/main/java/com/example/fashionforecastbackend/global/login/service/Impl/LoginServiceImpl.java
+++ b/src/main/java/com/example/fashionforecastbackend/global/login/service/Impl/LoginServiceImpl.java
@@ -4,6 +4,7 @@ import static com.example.fashionforecastbackend.global.error.ErrorCode.*;
 import static com.example.fashionforecastbackend.member.domain.constant.MemberRole.*;
 
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -76,10 +77,23 @@ public class LoginServiceImpl implements LoginService {
 
 	@Transactional
 	@Override
-	public void deleteAccount(final Long memberId) {
+	public void deleteAccount(final Long memberId, HttpServletResponse response) {
 		validateExistMember(memberId);
 		removeRefreshToken(memberId);
 		eventPublisher.publishEvent(MemberDeleteEvent.of(memberId));
+		deleteRefreshToken(response);
+	}
+
+	private void deleteRefreshToken(HttpServletResponse response) {
+		ResponseCookie cookie = ResponseCookie.from("refresh_token", "")
+			.maxAge(0)
+			.sameSite("Lax")
+			.secure(true)
+			.httpOnly(true)
+			.path("/")
+			.build();
+
+		response.setHeader("Set-Cookie", cookie.toString());
 	}
 
 	private void validateExistMember(final Long memberId) {

--- a/src/main/java/com/example/fashionforecastbackend/global/login/service/LoginService.java
+++ b/src/main/java/com/example/fashionforecastbackend/global/login/service/LoginService.java
@@ -12,7 +12,7 @@ public interface LoginService {
 
 	void removeRefreshToken(final Long memberId);
 
-	void deleteAccount(final Long memberId);
+	void deleteAccount(final Long memberId, HttpServletResponse response);
 
 	AccessTokenResponse issueAccessToken(final String refreshTokenRequest);
 }

--- a/src/main/java/com/example/fashionforecastbackend/member/domain/repository/MemberOutfitRepository.java
+++ b/src/main/java/com/example/fashionforecastbackend/member/domain/repository/MemberOutfitRepository.java
@@ -26,5 +26,6 @@ public interface MemberOutfitRepository extends JpaRepository<MemberOutfit, Long
 		final @Param("memberId") Long memberId);
 
 	@Modifying
+	@Query("DELETE FROM MemberOutfit m WHERE m.member.id = :memberId")
 	void deleteAllByMemberId(final Long memberId);
 }

--- a/src/main/resources/db/migration/V2__add_outfit.sql
+++ b/src/main/resources/db/migration/V2__add_outfit.sql
@@ -26,4 +26,6 @@ VALUES
 (29, '맨투맨', 'TOP', 'UNISEX', NOW(), NOW()),
 (30, '스타킹', 'BOTTOM', 'FEMALE', NOW(), NOW()),
 (31, '레깅스', 'BOTTOM', 'FEMALE', NOW(), NOW()),
-(32, '긴팔티', 'TOP', 'UNISEX', NOW(), NOW());
+(32, '긴팔티', 'TOP', 'UNISEX', NOW(), NOW()),
+(33, '짧은 치마', 'BOTTOM', 'FEMALE', NOW(), NOW()),
+(34, '긴 치마', 'BOTTOM', 'FEMALE', NOW(), NOW());

--- a/src/test/java/com/example/fashionforecastbackend/global/login/presentation/LoginControllerTest.java
+++ b/src/test/java/com/example/fashionforecastbackend/global/login/presentation/LoginControllerTest.java
@@ -147,7 +147,7 @@ class LoginControllerTest extends ControllerTest {
 	void deleteAccountTest() throws Exception {
 		//given
 
-		willDoNothing().given(loginService).deleteAccount(userDetail.memberId());
+		willDoNothing().given(loginService).deleteAccount(any(Long.class), any(HttpServletResponse.class));
 		//when
 		final ResultActions resultActions = performDeleteRequest("/account");
 		//then


### PR DESCRIPTION
## 📄 Summary
>
#147 
#### ✅ 계정 탈퇴 시 쿠키에서 리프레시 토큰을 삭제하는 로직을 추가하였습니다~

#### ✅ 계정 탈퇴 시 회원 정보가 남아있던 문제를 수정하였습니다~
- MemberOutfit 엔티티에 삭제 쿼리를 정의를 해놓아서, 소프트 삭제가 되는게 원인이었습니다
- MemberOutfitRepository의 deleteAllByMemberId()에 하드 삭제 되는 쿼리를 정의하여 해결하였습니다

#### ✅ 이외에 outfit 데이터 스키마에 짧은 치마, 긴 치마 인서트 쿼리를 추가하였습니다~

## 🙋🏻 More
>
