### PR TITLE
탈퇴 시 최근 검색어 전체 삭제 로직 추가

### DIFF
--- a/src/main/java/com/example/fashionforecastbackend/listener/DeleteEventListener.java
+++ b/src/main/java/com/example/fashionforecastbackend/listener/DeleteEventListener.java
@@ -5,9 +5,13 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import com.example.fashionforecastbackend.global.error.ErrorCode;
+import com.example.fashionforecastbackend.global.error.exception.MemberNotFoundException;
+import com.example.fashionforecastbackend.member.domain.Member;
 import com.example.fashionforecastbackend.member.domain.MemberDeleteEvent;
 import com.example.fashionforecastbackend.member.domain.repository.MemberOutfitRepository;
 import com.example.fashionforecastbackend.member.domain.repository.MemberRepository;
+import com.example.fashionforecastbackend.search.service.SearchService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +24,7 @@ public class DeleteEventListener {
 
 	private final MemberRepository memberRepository;
 	private final MemberOutfitRepository memberOutfitRepository;
+	private final SearchService searchService;
 
 
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -28,6 +33,15 @@ public class DeleteEventListener {
 		final Long memberId = event.memberId();
 		memberOutfitRepository.deleteAllByMemberId(memberId);
 		memberRepository.deleteById(memberId);
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@TransactionalEventListener(fallbackExecution = true)
+	public void deleteAllSearch(final MemberDeleteEvent event) {
+		final Long memberId = event.memberId();
+		final Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new MemberNotFoundException(ErrorCode.NOT_FOUND_MEMBER));
+		searchService.deleteAllSearch(member.getSocialId());
 	}
 
 }

--- a/src/main/java/com/example/fashionforecastbackend/search/service/SearchService.java
+++ b/src/main/java/com/example/fashionforecastbackend/search/service/SearchService.java
@@ -7,9 +7,11 @@ import com.example.fashionforecastbackend.search.dto.response.SearchResponse;
 
 public interface SearchService {
 
-	SearchResponse registSearch(String uuid, SearchRequest request);
+	SearchResponse registSearch(final String uuid, final SearchRequest request);
 
-	List<SearchResponse> getSearch(String uuid);
+	List<SearchResponse> getSearch(final String uuid);
 
-	void deleteSearch(String uuid, SearchRequest request);
+	void deleteSearch(final String uuid, final SearchRequest request);
+
+	void deleteAllSearch(final String uuid);
 }

--- a/src/main/java/com/example/fashionforecastbackend/search/service/impl/SearchServiceImpl.java
+++ b/src/main/java/com/example/fashionforecastbackend/search/service/impl/SearchServiceImpl.java
@@ -12,7 +12,6 @@ import com.example.fashionforecastbackend.search.domain.Search;
 import com.example.fashionforecastbackend.search.dto.request.SearchRequest;
 import com.example.fashionforecastbackend.search.dto.response.SearchResponse;
 import com.example.fashionforecastbackend.search.service.SearchService;
-import com.example.fashionforecastbackend.search.util.SearchValidator;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,12 +24,9 @@ public class SearchServiceImpl implements SearchService {
 	private static final String KEY_PREFIX = "Search";
 
 	private final RedisTemplate<String, Search> redisTemplate;
-	private final SearchValidator validator;
-
 
 	@Override
 	public SearchResponse registSearch(final String uuid, final SearchRequest request) {
-		validator.validateExistUser(uuid);
 		String key = KEY_PREFIX + uuid;
 		Search search = Search.builder()
 			.city(request.city())
@@ -51,7 +47,6 @@ public class SearchServiceImpl implements SearchService {
 
 	@Override
 	public List<SearchResponse> getSearch(final String uuid) {
-		validator.validateExistUser(uuid);
 		String key = KEY_PREFIX + uuid;
 		List<Search> searches = redisTemplate.opsForList().range(key, 0, 3);
 		List<SearchResponse> responses = new ArrayList<>();
@@ -65,7 +60,6 @@ public class SearchServiceImpl implements SearchService {
 
 	@Override
 	public void deleteSearch(final String uuid, final SearchRequest request) {
-		validator.validateExistUser(uuid);
 		String key = KEY_PREFIX + uuid;
 		Search search = Search.builder()
 			.city(request.city())
@@ -78,6 +72,12 @@ public class SearchServiceImpl implements SearchService {
 			throw new SearchNotExistException(ErrorCode.SEARCH_NOT_EXIST);
 		}
 
+	}
+
+	@Override
+	public void deleteAllSearch(final String uuid) {
+		final String key = KEY_PREFIX + uuid;
+		redisTemplate.delete(key);
 	}
 
 }


### PR DESCRIPTION
## 📄 Summary
>
#149 
#### 탈퇴 시 해당 계정의 최근 검색어가 전부 삭제 됩니다

#### 최근 검색어 api를 비회원과 회원이 공용으로 쓰기 위해 벨리데이트 부분을 삭제하였습니다
- 관련해서 추후에 비회원과 회원 api 분리가 필요하다면 수정할 예정입니다

## 🙋🏻 More
>
