### PR TITLE
refactor: 최근 검색어 삭제 로직 로그인 서비스 객체로 이동

### DIFF
--- a/src/main/java/com/example/fashionforecastbackend/listener/DeleteEventListener.java
+++ b/src/main/java/com/example/fashionforecastbackend/listener/DeleteEventListener.java
@@ -5,13 +5,9 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-import com.example.fashionforecastbackend.global.error.ErrorCode;
-import com.example.fashionforecastbackend.global.error.exception.MemberNotFoundException;
-import com.example.fashionforecastbackend.member.domain.Member;
 import com.example.fashionforecastbackend.member.domain.MemberDeleteEvent;
 import com.example.fashionforecastbackend.member.domain.repository.MemberOutfitRepository;
 import com.example.fashionforecastbackend.member.domain.repository.MemberRepository;
-import com.example.fashionforecastbackend.search.service.SearchService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,7 +20,6 @@ public class DeleteEventListener {
 
 	private final MemberRepository memberRepository;
 	private final MemberOutfitRepository memberOutfitRepository;
-	private final SearchService searchService;
 
 
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -33,15 +28,6 @@ public class DeleteEventListener {
 		final Long memberId = event.memberId();
 		memberOutfitRepository.deleteAllByMemberId(memberId);
 		memberRepository.deleteById(memberId);
-	}
-
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	@TransactionalEventListener(fallbackExecution = true)
-	public void deleteAllSearch(final MemberDeleteEvent event) {
-		final Long memberId = event.memberId();
-		final Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new MemberNotFoundException(ErrorCode.NOT_FOUND_MEMBER));
-		searchService.deleteAllSearch(member.getSocialId());
 	}
 
 }


### PR DESCRIPTION
## 📄 Summary
>
#151 
트랜잭션이 꼬여서 그런거였네요..

최근 검색어 삭제 -> 회원 삭제 순서 보장을 위해, 리스너에 있던 최근 검색어 삭제 로직으로 이동시켰습니다!

## 🙋🏻 More
>
